### PR TITLE
PHP 7 compatibility

### DIFF
--- a/HTTP/WebDAV/Server.php
+++ b/HTTP/WebDAV/Server.php
@@ -127,7 +127,7 @@ class HTTP_WebDAV_Server
      *
      * @param void
      */
-    function HTTP_WebDAV_Server() 
+    public function __construct()
     {
         // PHP messages destroy XML output -> switch them off
         ini_set("display_errors", 0);

--- a/Tools/_parse_lockinfo.php
+++ b/Tools/_parse_lockinfo.php
@@ -89,7 +89,7 @@ class _parse_lockinfo
      * @param  string  path of stream to read
      * @access public
      */
-    function _parse_lockinfo($path) 
+    public function __construct($path)
     {
         // we assume success unless problems occur
         $this->success = true;

--- a/Tools/_parse_propfind.php
+++ b/Tools/_parse_propfind.php
@@ -72,7 +72,7 @@ class _parse_propfind
      *
      * @access public
      */
-    function _parse_propfind($path) 
+    public function __construct($path)
     {
         // success state flag
         $this->success = true;

--- a/Tools/_parse_proppatch.php
+++ b/Tools/_parse_proppatch.php
@@ -89,7 +89,7 @@ class _parse_proppatch
      * @param  string  path of input stream 
      * @access public
      */
-    function _parse_proppatch($path) 
+    public function __construct($path)
     {
         $this->success = true;
 

--- a/package.xml
+++ b/package.xml
@@ -54,7 +54,7 @@ Bug #18694 Filesystem.php GetDir wrongly encoded filesnames containing single qu
  <dependencies>
   <required>
    <php>
-    <min>4.4</min>
+    <min>5.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>


### PR DESCRIPTION
PHP 4 constructors are producing E_DEPRECATED messages now - http://php.net/manual/en/migration70.deprecated.php
