### PR TITLE
Fix strncmp size argument in WebDav/Server.php

### DIFF
--- a/HTTP/WebDAV/Server.php
+++ b/HTTP/WebDAV/Server.php
@@ -1192,7 +1192,7 @@ class HTTP_WebDAV_Server
              (Not Implemented) response in such cases."
             */ 
             foreach ($this->_SERVER as $key => $val) {
-                if (strncmp($key, "HTTP_CONTENT", 11)) continue;
+                if (strncmp($key, "HTTP_CONTENT", 12)) continue;
                 switch ($key) {
                 case 'HTTP_CONTENT_ENCODING': // RFC 2616 14.11
                     // TODO support this if ext/zlib filters are available


### PR DESCRIPTION
This commit fixes a bug where a `strncmp($key, "HTTP_CONTENT", 11)` is called with an off-by-one size parameter, as the `"HTTP_CONTENT"` string length (without the null byte) is 12 and not 11.

There is not much impact here - if someone sends a header `ContenX` where `X` can be any char other than `'T'` the program will go to the `default:` branch and write out that this key is not supported:

```php
                default: 
                    // any other unknown Content-* headers
                    $this->http_status("501 not implemented"); 
                    echo "The service does not support '$key'"; 
                    return;
```